### PR TITLE
Sticking Gas Pedal

### DIFF
--- a/vector_robot/vector_bringup/launch/teleop/config/cmd_vel_mux.yaml
+++ b/vector_robot/vector_bringup/launch/teleop/config/cmd_vel_mux.yaml
@@ -14,7 +14,7 @@ subscribers:
 
   - name:        "Manual Override"
     topic:       "/vector/manual_override/cmd_vel"
-    timeout:     2.0
+    timeout:     0.1
     priority:    4
 
   - name:        "Assisted Teleop"


### PR DESCRIPTION
We found that under an assisted-teleop-always-on scenario, if the user lets the override switch go while the joystick lever is still pushed, the speed "sticks" (hence the analogy of a sticking gas pedal in a car) , as the timeout for that topic is very long. Reducing it helped alleviate this. Note that this happened with the robot in "idle", i.e., no navigation running, so it is not directly related to a conflict between planners. Not sure if this happened before the changes or not, as assisted teleop was rarely used previously, however, it might be good keeping into account that before the latest changes,  assisted teleop  would constantly stream twist commands, in contrast to the current situation of being muted when inactive.